### PR TITLE
remove missing commands from being contributed to the command pallette

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,16 +93,6 @@
 					"command": "fuchsia-git-helper.openAtMasterFromExplorerOsscs",
 					"when": "config.fuchsia-git-helper.codeViewer == 'osscs'"
 				}
-			],
-			"commandPalette": [
-				{
-					"command": "fuchsia-git-helper.openAtRevisionFromExplorer",
-					"when": "false"
-				},
-				{
-					"command": "fuchsia-git-helper.openAtMasterFromExplorer",
-					"when": "false"
-				}
 			]
 		},
 		"configuration": {


### PR DESCRIPTION
Was giving me warnings when opening the extension in debug mode.